### PR TITLE
Refactor file read / write to allow for testing

### DIFF
--- a/.github/workflows/quality-and-tests.yml
+++ b/.github/workflows/quality-and-tests.yml
@@ -32,4 +32,4 @@ jobs:
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_TEST_REPORTER_ID }}
         with:
-          prefix: github.com/sprak3000/go-glitch
+          prefix: github.com/sprak3000/xbar-whats-up

--- a/.github/workflows/quality-and-tests.yml
+++ b/.github/workflows/quality-and-tests.yml
@@ -1,0 +1,35 @@
+name: Code Quality & Tests
+
+on:
+  push: ~
+  pull_request: ~
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.9
+      - name: Install gotestsum
+        run: make install-gotestsum
+      - name: Install revive
+        run: go get -u github.com/mgechev/revive
+      - name: go mod tidy
+        run: go mod tidy
+      - name: go mod vendor
+        run: go mod vendor
+      - name: Lint the code
+        run: make lint
+      - name: Vet the code
+        run: make vet
+      - name: Run unit tests
+        run: make test-with-coverage
+      - name: Upload test coverage to CodeClimate
+        uses: paambaati/codeclimate-action@v3.0.0
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_TEST_REPORTER_ID }}
+        with:
+          prefix: github.com/sprak3000/go-glitch

--- a/Makefile
+++ b/Makefile
@@ -5,27 +5,26 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: analyze
-#analyze: lint vet test ## Run lint, vet, and test
-analyze: lint vet ## Run lint and vet
+analyze: lint vet test ## Run lint, vet, and test
 
 .PHONY: lint
 lint: ## Lint the code
 	# revive returns an exit code of 1 if no issues found. Strike that; reverse it.
 	@! revive -config .revive.toml ./... | grep -v vendor
 
-#.PHONY: test
-#test: unit-test ## Run the test suite(s).
-#
-#.PHONY: unit-test
-#unit-test: ## Run the unit tests.
-#	@gotestsum --format=standard-verbose -- -run '(?i)unit' ./...
-#
-#.PHONY: test-with-coverage
-#test-with-coverage: unit-test-with-coverage ## Run the test suite(s) and output test coverage data.
-#
-#.PHONY: unit-test-with-coverage
-#unit-test-with-coverage: ## Run the unit tests.
-#	@gotestsum --format=standard-verbose -- -run '(?i)unit' ./... -coverprofile=c.out
+.PHONY: test
+test: unit-test ## Run the test suite(s).
+
+.PHONY: unit-test
+unit-test: ## Run the unit tests.
+	@gotestsum --format=standard-verbose -- -run '(?i)unit' ./...
+
+.PHONY: test-with-coverage
+test-with-coverage: unit-test-with-coverage ## Run the test suite(s) and output test coverage data.
+
+.PHONY: unit-test-with-coverage
+unit-test-with-coverage: ## Run the unit tests.
+	@gotestsum --format=standard-verbose -- -run '(?i)unit' ./... -coverprofile=c.out
 
 .PHONY: vet
 vet: ## Verify `go vet` passes.

--- a/configuration/reader.go
+++ b/configuration/reader.go
@@ -1,0 +1,17 @@
+package configuration
+
+import "io/ioutil"
+
+// Reader provides the requirements for anyone implementing reading configuration files from disk
+type Reader interface {
+	ReadFile(filename string) ([]byte, error)
+}
+
+// FileReader implements the Reader interface for disk based configuration files
+type FileReader struct {
+}
+
+// ReadFile allows us to read configuration off of disk
+func (fr FileReader) ReadFile(filename string) ([]byte, error) {
+	return ioutil.ReadFile(filename)
+}

--- a/configuration/writer.go
+++ b/configuration/writer.go
@@ -1,0 +1,20 @@
+package configuration
+
+import (
+	"io/fs"
+	"io/ioutil"
+)
+
+// Writer provides the requirements for anyone implementing writing configuration files to disk
+type Writer interface {
+	WriteFile(filename string, data []byte, perm fs.FileMode) error
+}
+
+// FileWriter implements the Writer interface for disk based configuration files
+type FileWriter struct {
+}
+
+// WriteFile allows us to write configuration to disk
+func (w FileWriter) WriteFile(filename string, data []byte, perm fs.FileMode) error {
+	return ioutil.WriteFile(filename, data, perm)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,13 @@ go 1.17
 
 require github.com/sprak3000/go-client v1.0.1
 
-require github.com/sprak3000/go-glitch v1.0.1 // indirect
+require (
+	github.com/sprak3000/go-glitch v1.0.1
+	github.com/stretchr/testify v1.7.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sprak3000/whats-up
+module github.com/sprak3000/xbar-whats-up
 
 go 1.17
 

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,7 @@ golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/service/site.go
+++ b/service/site.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"time"
 
 	"github.com/sprak3000/go-client/client"
 	"github.com/sprak3000/go-glitch/glitch"
+	"github.com/sprak3000/whats-up/configuration"
 	"github.com/sprak3000/whats-up/status"
 	"github.com/sprak3000/whats-up/statuspageio"
 )
@@ -39,7 +39,7 @@ func (s Sites) GetOverview() status.Overview {
 	overview := status.Overview{
 		OverallStatus: "🟢",
 		List:          map[string][]statuspageio.Response{},
-		Errors:        []string{"test error"},
+		Errors:        []string{},
 	}
 
 	resp := statuspageio.Response{}
@@ -74,18 +74,18 @@ func (s Sites) GetOverview() status.Overview {
 }
 
 // LoadSites reads a JSON file containing a list of sites to monitor
-func LoadSites(filename string) (Sites, glitch.DataError) {
+func LoadSites(r configuration.Reader, w configuration.Writer, filename string) (Sites, glitch.DataError) {
 	var sites Sites
 
 	if filename == "" {
-		filename = ".whats-up.json"
+		filename = "./.whats-up.json"
 	}
 
-	config, rErr := ioutil.ReadFile(filename)
+	config, rErr := r.ReadFile(filename)
 	if rErr != nil {
 		// Create an empty configuration file
 		config = []byte("{\n}")
-		wErr := ioutil.WriteFile("./"+filename, config, 0644)
+		wErr := w.WriteFile(filename, config, 0644)
 		if wErr != nil {
 			return sites, glitch.NewDataError(wErr, ErrorUnableToWriteDefaultConfiguration, "unable to create default What's Up configuration")
 		}

--- a/service/site.go
+++ b/service/site.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/sprak3000/go-client/client"
 	"github.com/sprak3000/go-glitch/glitch"
-	"github.com/sprak3000/whats-up/configuration"
-	"github.com/sprak3000/whats-up/status"
-	"github.com/sprak3000/whats-up/statuspageio"
+	"github.com/sprak3000/xbar-whats-up/configuration"
+	"github.com/sprak3000/xbar-whats-up/status"
+	"github.com/sprak3000/xbar-whats-up/statuspageio"
 )
 
 // Error codes

--- a/service/site_test.go
+++ b/service/site_test.go
@@ -1,0 +1,106 @@
+package service
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sprak3000/go-glitch/glitch"
+	"github.com/sprak3000/whats-up/configuration"
+)
+
+type fileReaderWithFilename struct {
+}
+
+func (fr fileReaderWithFilename) ReadFile(_ string) ([]byte, error) {
+	return []byte(`{"CodeClimate":{"url":"https://status.circleci.com","slug":"/api/v2/status.json"}}`), nil
+}
+
+type fileReaderReturnsInvalidContents struct {
+}
+
+func (fr fileReaderReturnsInvalidContents) ReadFile(_ string) ([]byte, error) {
+	return []byte(`{`), nil
+}
+
+type fileReaderWithoutFilename struct {
+}
+
+func (fr fileReaderWithoutFilename) ReadFile(_ string) ([]byte, error) {
+	return nil, errors.New("read err")
+}
+
+type fileWriterSuccess struct {
+}
+
+func (fw fileWriterSuccess) WriteFile(_ string, _ []byte, _ fs.FileMode) error {
+	return nil
+}
+
+type fileWriterErr struct {
+}
+
+func (fw fileWriterErr) WriteFile(_ string, _ []byte, _ fs.FileMode) error {
+	return errors.New("write err")
+}
+
+func TestUnit_LoadSites(t *testing.T) {
+	tests := map[string]struct {
+		reader        configuration.Reader
+		writer        configuration.Writer
+		filename      string
+		expectedSites Sites
+		expectedErr   glitch.DataError
+		validate      func(t *testing.T, expectedSites, actualSites Sites, expectedErr, actualErr glitch.DataError)
+	}{
+		"base path- filename given": {
+			reader:   fileReaderWithFilename{},
+			filename: "test-config.json",
+			expectedSites: Sites{
+				"CodeClimate": {
+					URL:  "https://status.circleci.com",
+					Slug: "/api/v2/status.json",
+				},
+			},
+			validate: func(t *testing.T, expectedSites, actualSites Sites, expectedErr, actualErr glitch.DataError) {
+				require.NoError(t, actualErr)
+				require.Equal(t, expectedSites, actualSites)
+			},
+		},
+		"base path- no filename given": {
+			reader:        fileReaderWithoutFilename{},
+			writer:        fileWriterSuccess{},
+			expectedSites: Sites{},
+			validate: func(t *testing.T, expectedSites, actualSites Sites, expectedErr, actualErr glitch.DataError) {
+				require.NoError(t, actualErr)
+				require.Equal(t, expectedSites, actualSites)
+			},
+		},
+		"exceptional path- cannot write configuration file": {
+			reader:      fileReaderWithoutFilename{},
+			writer:      fileWriterErr{},
+			expectedErr: glitch.NewDataError(errors.New("write err"), ErrorUnableToWriteDefaultConfiguration, "unable to create default What's Up configuration"),
+			validate: func(t *testing.T, expectedSites, actualSites Sites, expectedErr, actualErr glitch.DataError) {
+				require.Error(t, actualErr)
+				require.Equal(t, expectedErr.Code(), actualErr.Code())
+			},
+		},
+		"exceptional path- cannot unmarshal configuration file": {
+			reader:      fileReaderReturnsInvalidContents{},
+			filename:    "test-config.json",
+			expectedErr: glitch.NewDataError(nil, ErrorUnableToParseConfiguration, "error parsing What's Up configuration"),
+			validate: func(t *testing.T, expectedSites, actualSites Sites, expectedErr, actualErr glitch.DataError) {
+				require.Error(t, actualErr)
+				require.Equal(t, expectedErr.Code(), actualErr.Code())
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			s, err := LoadSites(tc.reader, tc.writer, tc.filename)
+			tc.validate(t, tc.expectedSites, s, tc.expectedErr, err)
+		})
+	}
+}

--- a/service/site_test.go
+++ b/service/site_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sprak3000/go-glitch/glitch"
-	"github.com/sprak3000/whats-up/configuration"
+	"github.com/sprak3000/xbar-whats-up/configuration"
 )
 
 type fileReaderWithFilename struct {

--- a/status/overview.go
+++ b/status/overview.go
@@ -3,7 +3,7 @@ package status
 import (
 	"fmt"
 
-	"github.com/sprak3000/whats-up/statuspageio"
+	"github.com/sprak3000/xbar-whats-up/statuspageio"
 )
 
 // List is a mapping of status codes to services reporting that status code

--- a/whats-up.1h.go
+++ b/whats-up.1h.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sprak3000/whats-up/configuration"
-	"github.com/sprak3000/whats-up/service"
+	"github.com/sprak3000/xbar-whats-up/configuration"
+	"github.com/sprak3000/xbar-whats-up/service"
 )
 
 func main() {

--- a/whats-up.1h.go
+++ b/whats-up.1h.go
@@ -11,11 +11,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/sprak3000/whats-up/configuration"
 	"github.com/sprak3000/whats-up/service"
 )
 
 func main() {
-	sites, lErr := service.LoadSites("./.whats-up.json")
+	sites, lErr := service.LoadSites(configuration.FileReader{}, configuration.FileWriter{}, "./.whats-up.json")
 	if lErr != nil {
 		fmt.Println("What's Up Error")
 		fmt.Println("---")


### PR DESCRIPTION
- Create read and write interfaces.
- Create file read / write types to satisfy the interfaces.
- Convert `LoadSites` to take in a reader and writer interface and use them.
- Cover `LoadSites` with unit tests.
- Add GitHub workflow to run quality checks and unit tests.