### PR TITLE
Simplify the configuration

### DIFF
--- a/.whats-up.sample.json
+++ b/.whats-up.sample.json
@@ -1,26 +1,26 @@
 {
   "CircleCI": {
-    "url": "https://status.circleci.com",
-    "slug": "/api/v2/status.json"
+    "url": "https://status.circleci.com/api/v2/status.json",
+    "type": "statuspage.io"
   },
   "CodeClimate": {
-    "url": "https://status.codeclimate.com",
-    "slug": "/api/v2/status.json"
+    "url": "https://status.codeclimate.com/api/v2/status.json",
+    "type": "statuspage.io"
   },
   "DataDog": {
-    "url": "https://status.datadoghq.com",
-    "slug": "/api/v2/status.json"
+    "url": "https://status.datadoghq.com/api/v2/status.json",
+    "type": "statuspage.io"
   },
   "GitHub": {
-    "url": "https://www.githubstatus.com",
-    "slug": "/api/v2/status.json"
+    "url": "https://www.githubstatus.com/api/v2/status.json",
+    "type": "statuspage.io"
   },
   "Reddit": {
-    "url": "https://www.redditstatus.com",
-    "slug": "/api/v2/status.json"
+    "url": "https://www.redditstatus.com/api/v2/status.json",
+    "type": "statuspage.io"
   },
   "Sentry": {
-    "url": "https://status.sentry.io",
-    "slug": "/api/v2/status.json"
+    "url": "https://status.sentry.io/api/v2/status.json",
+    "type": "statuspage.io"
   }
 }

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ entry in the configuration file like this:
 
 ```json
   "CodeClimate": {
-    "url": "https://status.codeclimate.com",
-    "slug": "/api/v2/status.json"
+    "url": "https://status.codeclimate.com/api/v2/status.json",
+    "type": "statuspage.io"
   }
 ```
 

--- a/service/client.go
+++ b/service/client.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"time"
@@ -48,7 +49,11 @@ func (cr ClientReader) ReadStatus(serviceFinder client.ServiceFinder, serviceNam
 // NewClientServiceFinder returns a client.ServiceFinder suitable for use with go-client
 func NewClientServiceFinder(sites Sites) client.ServiceFinder {
 	return func(serviceName string, useTLS bool) (url.URL, error) {
-		u, err := url.Parse(sites[serviceName].URL)
-		return *u, err
+		u, ok := sites[serviceName]
+		if !ok {
+			return url.URL{}, errors.New("unable to find " + serviceName + " in the service list")
+		}
+
+		return u.URL, nil
 	}
 }

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnit_NewClientServiceFinder(t *testing.T) {
+	codeClimateURL, err := url.Parse("https://status.codeclimate.com/api/v2/status.json")
+	require.NoError(t, err)
+
+	circleciURL, err := url.Parse("https://status.circleci.com/api/v2/status.json")
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		sites       Sites
+		serviceName string
+		expectedURL url.URL
+		expectedErr error
+		validate    func(t *testing.T, expectedURL, actualURL url.URL, expectedErr, actualErr error)
+	}{
+		"base path": {
+			sites: Sites{
+				"CodeClimate": {
+					URL:  *codeClimateURL,
+					Type: "statuspage.io",
+				},
+				"CircleCI": {
+					URL:  *circleciURL,
+					Type: "statuspage.io",
+				},
+			},
+			serviceName: "CodeClimate",
+			expectedURL: *codeClimateURL,
+			validate: func(t *testing.T, expectedURL, actualURL url.URL, expectedErr, actualErr error) {
+				require.NoError(t, actualErr)
+				require.Equal(t, expectedURL, actualURL)
+			},
+		},
+		"exceptional path- unable to find service": {
+			sites: Sites{
+				"CodeClimate": {
+					URL:  *codeClimateURL,
+					Type: "statuspage.io",
+				},
+				"CircleCI": {
+					URL:  *circleciURL,
+					Type: "statuspage.io",
+				},
+			},
+			serviceName: "GitHub",
+			expectedErr: errors.New("unable to find GitHub in the service list"),
+			validate: func(t *testing.T, expectedURL, actualURL url.URL, expectedErr, actualErr error) {
+				require.Error(t, actualErr)
+				require.Equal(t, expectedErr, actualErr)
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := NewClientServiceFinder(tc.sites)
+			u, err := f(tc.serviceName, true)
+			tc.validate(t, tc.expectedURL, u, tc.expectedErr, err)
+		})
+	}
+}

--- a/service/site.go
+++ b/service/site.go
@@ -41,7 +41,7 @@ func (s *Site) UnmarshalJSON(data []byte) error {
 
 	u, pErr := url.Parse(tmp.URL)
 	if pErr != nil {
-		return err
+		return pErr
 	}
 
 	s.URL = *u


### PR DESCRIPTION
- Rather than URL / slug, just make is URL in the config JSON.
- Add `type` to the config JSON. Not used for now but maybe going forward.
- Add unmarshal method to `Site` to handle parsing the URL field into a `url.URL` type.
- Update client service finder to handle the new structure.
- Update sample config and documentation.