### PR TITLE
Issue #8 -- Icon color is incorrect when there is a major and minor outage

### DIFF
--- a/service/site.go
+++ b/service/site.go
@@ -55,7 +55,7 @@ type Sites map[string]Site
 // GetOverview returns the details about the services monitored
 func (sites Sites) GetOverview(serviceFinder client.ServiceFinder, reader Reader) status.Overview {
 	overview := status.Overview{
-		OverallStatus: "🟢",
+		OverallStatus: "none",
 		List:          map[string][]statuspageio.Response{},
 		Errors:        []string{},
 	}
@@ -69,10 +69,12 @@ func (sites Sites) GetOverview(serviceFinder client.ServiceFinder, reader Reader
 
 		switch resp.Status.Indicator {
 		case "major":
-			overview.OverallStatus = "🔴"
+			overview.OverallStatus = "major"
 			overview.List["major"] = append(overview.List["major"], resp)
 		case "minor":
-			overview.OverallStatus = "🟠"
+			if overview.OverallStatus != "major" {
+				overview.OverallStatus = "minor"
+			}
 			overview.List["minor"] = append(overview.List["minor"], resp)
 		default:
 			overview.List["none"] = append(overview.List["none"], resp)

--- a/status/overview.go
+++ b/status/overview.go
@@ -19,7 +19,14 @@ type Overview struct {
 
 // Display outputs the data in the xbar format
 func (o Overview) Display() {
-	fmt.Println(o.OverallStatus)
+	switch o.OverallStatus {
+	case "major":
+		fmt.Println("🔴")
+	case "minor":
+		fmt.Println("🟠")
+	default:
+		fmt.Println("🟢")
+	}
 
 	fmt.Println("---")
 	if len(o.List["major"]) > 0 {


### PR DESCRIPTION
- Use strings instead of emojis on the overview setting.
- Wrap minor overview setting in a check there isn't already a major ongoing.
- Convert overview to emojis in `Display()`.