### PR TITLE
Issue #11 - Decouple display of status from statuspage format

### DIFF
--- a/.github/workflows/quality-and-tests.yml
+++ b/.github/workflows/quality-and-tests.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.9
+          go-version: 1.19.2
       - name: Install gotestsum
         run: make install-gotestsum
       - name: Install revive

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.17.9
+golang 1.19.2

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ analyze: lint vet test ## Run lint, vet, and test
 
 .PHONY: lint
 lint: ## Lint the code
-	# revive returns an exit code of 1 if no issues found. Strike that; reverse it.
 	@! revive -config .revive.toml ./... | grep -v vendor
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -55,12 +55,12 @@ setup-asdf: ## Install Go via asdf
 .PHONY: install-goimports
 install-goimports: ## Install goimports
 	@echo ">>>> Installing goimports"
-	@go get golang.org/x/tools/cmd/goimports
+	@go install golang.org/x/tools/cmd/goimports@latest
 
 .PHONY: install-gotestsum
 install-gotestsum: ## Install gotestsum
 	@echo ">>>> Installing gotestsum"
-	@go get gotest.tools/gotestsum
+	@go install gotest.tools/gotestsum@latest
 
 .PHONY: asdf-reshim
 asdf-reshim: ## Reshim asdf

--- a/configuration/reader.go
+++ b/configuration/reader.go
@@ -1,3 +1,4 @@
+// Package configuration handles reading and writing the configuration file for the plugin
 package configuration
 
 import "io/ioutil"

--- a/service/client.go
+++ b/service/client.go
@@ -1,3 +1,4 @@
+// Package service handles communicating with sites to obtain their current status details
 package service
 
 import (

--- a/service/site.go
+++ b/service/site.go
@@ -1,3 +1,4 @@
+// Package service handles communicating with sites to obtain their current status details
 package service
 
 import (
@@ -8,7 +9,6 @@ import (
 	"github.com/sprak3000/go-glitch/glitch"
 	"github.com/sprak3000/xbar-whats-up/configuration"
 	"github.com/sprak3000/xbar-whats-up/status"
-	"github.com/sprak3000/xbar-whats-up/statuspageio"
 )
 
 // Error codes
@@ -56,7 +56,7 @@ type Sites map[string]Site
 func (sites Sites) GetOverview(serviceFinder client.ServiceFinder, reader Reader) status.Overview {
 	overview := status.Overview{
 		OverallStatus: "none",
-		List:          map[string][]statuspageio.Response{},
+		List:          map[string][]status.Details{},
 		Errors:        []string{},
 	}
 
@@ -67,7 +67,7 @@ func (sites Sites) GetOverview(serviceFinder client.ServiceFinder, reader Reader
 			continue
 		}
 
-		switch resp.Status.Indicator {
+		switch resp.Indicator() {
 		case "major":
 			overview.OverallStatus = "major"
 			overview.List["major"] = append(overview.List["major"], resp)

--- a/service/site_test.go
+++ b/service/site_test.go
@@ -83,9 +83,9 @@ func TestUnit_GetOverview(t *testing.T) {
 			reader: clientReaderSeverityMajor{},
 			expectedOverview: status.Overview{
 				OverallStatus: "major",
-				List: map[string][]statuspageio.Response{
+				List: map[string][]status.Details{
 					"major": {
-						{
+						statuspageio.Response{
 							Page: statuspageio.Page{
 								ID:   "circle-ci",
 								Name: "CircleCI",
@@ -98,7 +98,7 @@ func TestUnit_GetOverview(t *testing.T) {
 						},
 					},
 					"minor": {
-						{
+						statuspageio.Response{
 							Page: statuspageio.Page{
 								ID:   "code-climate",
 								Name: "CodeClimate",
@@ -131,9 +131,9 @@ func TestUnit_GetOverview(t *testing.T) {
 			reader: clientReaderSeverityMinor{},
 			expectedOverview: status.Overview{
 				OverallStatus: "minor",
-				List: map[string][]statuspageio.Response{
+				List: map[string][]status.Details{
 					"minor": {
-						{
+						statuspageio.Response{
 							Page: statuspageio.Page{
 								ID:   "circle-ci",
 								Name: "CircleCI",
@@ -146,7 +146,7 @@ func TestUnit_GetOverview(t *testing.T) {
 						},
 					},
 					"none": {
-						{
+						statuspageio.Response{
 							Page: statuspageio.Page{
 								ID:   "code-climate",
 								Name: "CodeClimate",
@@ -179,9 +179,9 @@ func TestUnit_GetOverview(t *testing.T) {
 			reader: clientReaderHasError{},
 			expectedOverview: status.Overview{
 				OverallStatus: "none",
-				List: map[string][]statuspageio.Response{
+				List: map[string][]status.Details{
 					"none": {
-						{
+						statuspageio.Response{
 							Page: statuspageio.Page{
 								ID:   "code-climate",
 								Name: "CodeClimate",

--- a/status/details.go
+++ b/status/details.go
@@ -1,0 +1,14 @@
+// Package status is an abstraction for handling and displaying status details from various services
+package status
+
+import (
+	"time"
+)
+
+// Details provides an interface for extracting information from a service's status response
+type Details interface {
+	Indicator() string
+	Name() string
+	UpdatedAt() time.Time
+	URL() string
+}

--- a/status/overview.go
+++ b/status/overview.go
@@ -1,13 +1,12 @@
+// Package status is an abstraction for handling and displaying status details from various services
 package status
 
 import (
 	"fmt"
-
-	"github.com/sprak3000/xbar-whats-up/statuspageio"
 )
 
 // List is a mapping of status codes to services reporting that status code
-type List map[string][]statuspageio.Response
+type List map[string][]Details
 
 // Overview provides an overall status for all services monitored -- most severe status wins -- along with all the
 // services categorized by status
@@ -31,21 +30,21 @@ func (o Overview) Display() {
 	fmt.Println("---")
 	if len(o.List["major"]) > 0 {
 		for _, v := range o.List["major"] {
-			fmt.Println("\u001B[31;1m" + v.Page.Name + "\u001b[0m" + "\u001b[30m" + " (" + v.Page.UpdatedAt.Format("2006 Jan 02") + ") | href=" + v.Page.URL)
+			fmt.Println("\u001B[31;1m" + v.Name() + "\u001b[0m" + "\u001b[30m" + " (" + v.UpdatedAt().Format("2006 Jan 02") + ") | href=" + v.URL())
 		}
 	}
 
 	fmt.Println("---")
 	if len(o.List["minor"]) > 0 {
 		for _, v := range o.List["minor"] {
-			fmt.Println("\u001b[38;5;208m" + v.Page.Name + "\u001b[0m" + "\u001b[30m" + " (" + v.Page.UpdatedAt.Format("2006 Jan 02") + ") | href=" + v.Page.URL)
+			fmt.Println("\u001b[38;5;208m" + v.Name() + "\u001b[0m" + "\u001b[30m" + " (" + v.UpdatedAt().Format("2006 Jan 02") + ") | href=" + v.URL())
 		}
 	}
 
 	fmt.Println("---")
 	if len(o.List["none"]) > 0 {
 		for _, v := range o.List["none"] {
-			fmt.Println("\u001B[32;1m" + v.Page.Name + "\u001b[0m" + "\u001b[30m" + " (" + v.Page.UpdatedAt.Format("2006 Jan 02") + ") | href=" + v.Page.URL)
+			fmt.Println("\u001B[32;1m" + v.Name() + "\u001b[0m" + "\u001b[30m" + " (" + v.UpdatedAt().Format("2006 Jan 02") + ") | href=" + v.URL())
 		}
 	}
 

--- a/statuspageio/response.go
+++ b/statuspageio/response.go
@@ -1,6 +1,9 @@
+// Package statuspageio handles communicating with status pages following the statuspage.io format
 package statuspageio
 
-import "time"
+import (
+	"time"
+)
 
 // Page represents the page information
 type Page struct {
@@ -21,4 +24,24 @@ type Status struct {
 type Response struct {
 	Page   Page   `json:"page"`
 	Status Status `json:"status"`
+}
+
+// Indicator returns the current status for the service
+func (r Response) Indicator() string {
+	return r.Status.Indicator
+}
+
+// Name returns the name of the service
+func (r Response) Name() string {
+	return r.Page.Name
+}
+
+// UpdatedAt returns the date / time of the most recent status update for the service
+func (r Response) UpdatedAt() time.Time {
+	return r.Page.UpdatedAt
+}
+
+// URL returns the page the service hosts to display more details about current and past status updates
+func (r Response) URL() string {
+	return r.Page.URL
 }

--- a/whats-up.1h.go
+++ b/whats-up.1h.go
@@ -5,6 +5,7 @@
 // <xbar.desc>Tracks if services are reporting any outages.</xbar.desc>
 // <xbar.dependencies>golang</xbar.dependencies>
 
+// Package main is the entry point for running the plugin
 package main
 
 import (


### PR DESCRIPTION
- Create new `status.Details` interface with the necessary methods defined to cover what information we extract and display currently.
- Have `statuspageio.Response` implement the new `Details` interface.
- Update the `status.List` type to be a map containing items implementing the new `Details` interface.
- Update the logic of pulling status details and displaying the data to use the new methods from the `Details` interface. Update unit tests accordingly.
- Add package comments based on latest lint rule updates.
- Remove revive comment from `Makefile`.