### PR TITLE
Issue #17 - Decouple site reading from statuspage.io

### DIFF
--- a/service/client.go
+++ b/service/client.go
@@ -2,49 +2,33 @@
 package service
 
 import (
-	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"net/url"
-	"time"
 
 	"github.com/sprak3000/go-client/client"
 	"github.com/sprak3000/go-glitch/glitch"
+	"github.com/sprak3000/xbar-whats-up/status"
 	"github.com/sprak3000/xbar-whats-up/statuspageio"
-)
-
-// Error codes
-const (
-	ErrorUnableToMakeClientRequest   = "UNABLE_TO_MAKE_CLIENT_REQUEST"
-	ErrorUnableToParseClientResponse = "UNABLE_TO_PARSE_CLIENT_RESPONSE"
 )
 
 // Reader provides the requirements for anyone implementing reading a service's status
 type Reader interface {
-	ReadStatus(serviceFinder client.ServiceFinder, serviceName, slug string) (statuspageio.Response, glitch.DataError)
+	ReadStatus(serviceFinder client.ServiceFinder, serviceName, slug string) (status.Details, glitch.DataError)
 }
 
-// ClientReader implements the Reader interface for go-client based reading of a service's status
-type ClientReader struct {
-}
+// ReaderServiceFinder is an alias for the closure that finds a Reader based on the given service type
+type ReaderServiceFinder func(serviceType string) (Reader, error)
 
-// ReadStatus allows us to use go-client to read a service's status
-func (cr ClientReader) ReadStatus(serviceFinder client.ServiceFinder, serviceName, slug string) (statuspageio.Response, glitch.DataError) {
-	resp := statuspageio.Response{}
-
-	c := client.NewBaseClient(serviceFinder, serviceName, true, 10*time.Second, nil)
-	_, respBytes, err := c.MakeRequest(context.Background(), "GET", slug, nil, nil, nil)
-	if err != nil {
-		return resp, glitch.NewDataError(err, ErrorUnableToMakeClientRequest, fmt.Sprintf("unable to make client request for %s: %v", serviceName, err))
+// NewReaderServiceFinder returns a service.ReaderServiceFinder to provider a Reader based on the given service type
+func NewReaderServiceFinder() ReaderServiceFinder {
+	return func(serviceType string) (Reader, error) {
+		switch serviceType {
+		case statuspageio.ServiceType:
+			return statuspageio.ClientReader{}, nil
+		default:
+			return nil, errors.New("reader not implemented for type " + serviceType)
+		}
 	}
-
-	uErr := json.Unmarshal(respBytes, &resp)
-	if uErr != nil {
-		return resp, glitch.NewDataError(uErr, ErrorUnableToParseClientResponse, fmt.Sprintf("unable to parse client response for %s: %v", serviceName, uErr))
-	}
-
-	return resp, nil
 }
 
 // NewClientServiceFinder returns a client.ServiceFinder suitable for use with go-client

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/sprak3000/xbar-whats-up/statuspageio"
 )
 
 func TestUnit_NewClientServiceFinder(t *testing.T) {
@@ -26,11 +28,11 @@ func TestUnit_NewClientServiceFinder(t *testing.T) {
 			sites: Sites{
 				"CodeClimate": {
 					URL:  *codeClimateURL,
-					Type: "statuspage.io",
+					Type: statuspageio.ServiceType,
 				},
 				"CircleCI": {
 					URL:  *circleciURL,
-					Type: "statuspage.io",
+					Type: statuspageio.ServiceType,
 				},
 			},
 			serviceName: "CodeClimate",
@@ -44,11 +46,11 @@ func TestUnit_NewClientServiceFinder(t *testing.T) {
 			sites: Sites{
 				"CodeClimate": {
 					URL:  *codeClimateURL,
-					Type: "statuspage.io",
+					Type: statuspageio.ServiceType,
 				},
 				"CircleCI": {
 					URL:  *circleciURL,
-					Type: "statuspage.io",
+					Type: statuspageio.ServiceType,
 				},
 			},
 			serviceName: "GitHub",
@@ -64,6 +66,39 @@ func TestUnit_NewClientServiceFinder(t *testing.T) {
 			f := NewClientServiceFinder(tc.sites)
 			u, err := f(tc.serviceName, true)
 			tc.validate(t, tc.expectedURL, u, tc.expectedErr, err)
+		})
+	}
+}
+
+func TestUnit_NewReaderServiceFinder(t *testing.T) {
+	tests := map[string]struct {
+		serviceType    string
+		expectedReader Reader
+		expectedErr    error
+		validate       func(t *testing.T, expectedReader, actualReader Reader, expectedErr, actualErr error)
+	}{
+		"base path- statuspage.io": {
+			serviceType:    statuspageio.ServiceType,
+			expectedReader: statuspageio.ClientReader{},
+			validate: func(t *testing.T, expectedReader, actualReader Reader, expectedErr, actualErr error) {
+				require.NoError(t, actualErr)
+				require.Equal(t, expectedReader, actualReader)
+			},
+		},
+		"exceptional path- unsupported service type": {
+			serviceType: "not-a-finger",
+			expectedErr: errors.New("reader not implemented for type not-a-finger"),
+			validate: func(t *testing.T, expectedReader, actualReader Reader, expectedErr, actualErr error) {
+				require.Error(t, actualErr)
+				require.Equal(t, expectedErr, actualErr)
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := NewReaderServiceFinder()
+			r, fErr := f(tc.serviceType)
+			tc.validate(t, tc.expectedReader, r, tc.expectedErr, fErr)
 		})
 	}
 }

--- a/service/site_test.go
+++ b/service/site_test.go
@@ -214,10 +214,6 @@ func TestUnit_GetOverview(t *testing.T) {
 					URL:  *codeClimateURL,
 					Type: statuspageio.ServiceType,
 				},
-				"CircleCI": {
-					URL:  *circleciURL,
-					Type: statuspageio.ServiceType,
-				},
 			},
 			readerFinder: func(serviceName string) (Reader, error) {
 				return nil, errors.New("not supported")
@@ -227,7 +223,6 @@ func TestUnit_GetOverview(t *testing.T) {
 				List:          map[string][]status.Details{},
 				Errors: []string{
 					"CodeClimate uses an unsupported service type statuspage.io",
-					"CircleCI uses an unsupported service type statuspage.io",
 				},
 			},
 			validate: func(t *testing.T, expectedOverview, actualOverview status.Overview) {

--- a/status/details.go
+++ b/status/details.go
@@ -2,7 +2,18 @@
 package status
 
 import (
+	"context"
+	"net/http"
 	"time"
+
+	"github.com/sprak3000/go-client/client"
+	"github.com/sprak3000/go-glitch/glitch"
+)
+
+// Error codes
+const (
+	ErrorUnableToMakeClientRequest   = "UNABLE_TO_MAKE_CLIENT_REQUEST"
+	ErrorUnableToParseClientResponse = "UNABLE_TO_PARSE_CLIENT_RESPONSE"
 )
 
 // Details provides an interface for extracting information from a service's status response
@@ -11,4 +22,11 @@ type Details interface {
 	Name() string
 	UpdatedAt() time.Time
 	URL() string
+}
+
+// Get makes the network request to get a status page
+func Get(serviceFinder client.ServiceFinder, serviceName, slug string) ([]byte, glitch.DataError) {
+	c := client.NewBaseClient(serviceFinder, serviceName, true, 10*time.Second, nil)
+	_, respBytes, err := c.MakeRequest(context.Background(), http.MethodGet, slug, nil, nil, nil)
+	return respBytes, err
 }

--- a/statuspageio/response.go
+++ b/statuspageio/response.go
@@ -2,8 +2,17 @@
 package statuspageio
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
+
+	"github.com/sprak3000/go-client/client"
+	"github.com/sprak3000/go-glitch/glitch"
+	"github.com/sprak3000/xbar-whats-up/status"
 )
+
+// ServiceType is the name we use for various checks
+const ServiceType = "statuspage.io"
 
 // Page represents the page information
 type Page struct {
@@ -18,6 +27,27 @@ type Page struct {
 type Status struct {
 	Indicator   string `json:"indicator"`
 	Description string `json:"description"`
+}
+
+// ClientReader implements the Reader interface for go-client based reading of a service's status
+type ClientReader struct {
+}
+
+// ReadStatus handles communicating with the service to get its status details
+func (cr ClientReader) ReadStatus(serviceFinder client.ServiceFinder, serviceName, slug string) (status.Details, glitch.DataError) {
+	resp := Response{}
+
+	respBytes, err := status.Get(serviceFinder, serviceName, slug)
+	if err != nil {
+		return resp, glitch.NewDataError(err, status.ErrorUnableToMakeClientRequest, fmt.Sprintf("unable to make client request for %s: %v", serviceName, err))
+	}
+
+	uErr := json.Unmarshal(respBytes, &resp)
+	if uErr != nil {
+		return resp, glitch.NewDataError(uErr, status.ErrorUnableToParseClientResponse, fmt.Sprintf("unable to parse client response for %s: %v", serviceName, uErr))
+	}
+
+	return resp, nil
 }
 
 // Response is the structure returned by statuspage.io powered service status pages

--- a/whats-up.1h.go
+++ b/whats-up.1h.go
@@ -1,5 +1,5 @@
 // <xbar.title>What's Up?</xbar.title>
-// <xbar.version>v1.0</xbar.version>
+// <xbar.version>v0.11.0</xbar.version>
 // <xbar.author>Luis A. Cruz</xbar.author>
 // <xbar.author.github>sprak3000</xbar.author.github>
 // <xbar.desc>Tracks if services are reporting any outages.</xbar.desc>
@@ -25,5 +25,5 @@ func main() {
 		os.Exit(1)
 	}
 
-	sites.GetOverview(service.NewClientServiceFinder(sites), service.ClientReader{}).Display()
+	sites.GetOverview(service.NewClientServiceFinder(sites), service.NewReaderServiceFinder()).Display()
 }


### PR DESCRIPTION
- Create a "Reader Service Finder" to take in a service type and return the appropriate reader or an "unsupported" error if not found.
- App startup uses `NewReaderServiceFinder()` and passes in finder to the `GetOverview`.
- `GetOverview` uses the finder to get the reader.
- `statuspageio` package defines a `ClientReader` struct implementing the `Reader` interface.
- Shuffling of error messages, etc. around.
- `status` package now has `Get` helper to perform the actual network fetch of a status page.