### PR TITLE
Issue #10 - Support Slack status

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a plugin for [xbar](https://github.com/matryer/xbar) to quickly show in 
 services you depend on. It currently understands the following formats:
 
 - statuspage.io JSON responses (Example: [reddit Status](https://www.redditstatus.com/api/v2/status.json))
+- [Slack API 2.0 JSON responses](https://api.slack.com/docs/slack-status#v2_0_0__current-status-api)
 
 ## Requirements
 
@@ -21,13 +22,17 @@ services you depend on. It currently understands the following formats:
 make create-config
 ```
 
-Using CodeClimate's status page (`https://status.codeclimate.com/api/v2/status.json`) as an example, we would create an
+Using CodeClimate's status page (`https://status.codeclimate.com/api/v2/status.json`) and Slack's as examples, we would create an
 entry in the configuration file like this:
 
 ```json
   "CodeClimate": {
     "url": "https://status.codeclimate.com/api/v2/status.json",
     "type": "statuspage.io"
+  },
+  "Slack": {
+    "url": "https://status.slack.com/api/v2.0.0/current",
+    "type": "slack"
   }
 ```
 

--- a/service/client.go
+++ b/service/client.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sprak3000/go-client/client"
 	"github.com/sprak3000/go-glitch/glitch"
+	"github.com/sprak3000/xbar-whats-up/slack"
 	"github.com/sprak3000/xbar-whats-up/status"
 	"github.com/sprak3000/xbar-whats-up/statuspageio"
 )
@@ -25,6 +26,8 @@ func NewReaderServiceFinder() ReaderServiceFinder {
 		switch serviceType {
 		case statuspageio.ServiceType:
 			return statuspageio.ClientReader{}, nil
+		case slack.ServiceType:
+			return slack.ClientReader{}, nil
 		default:
 			return nil, errors.New("reader not implemented for type " + serviceType)
 		}

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/sprak3000/xbar-whats-up/slack"
 	"github.com/sprak3000/xbar-whats-up/statuspageio"
 )
 
@@ -80,6 +81,14 @@ func TestUnit_NewReaderServiceFinder(t *testing.T) {
 		"base path- statuspage.io": {
 			serviceType:    statuspageio.ServiceType,
 			expectedReader: statuspageio.ClientReader{},
+			validate: func(t *testing.T, expectedReader, actualReader Reader, expectedErr, actualErr error) {
+				require.NoError(t, actualErr)
+				require.Equal(t, expectedReader, actualReader)
+			},
+		},
+		"base path- slack": {
+			serviceType:    slack.ServiceType,
+			expectedReader: slack.ClientReader{},
 			validate: func(t *testing.T, expectedReader, actualReader Reader, expectedErr, actualErr error) {
 				require.NoError(t, actualErr)
 				require.Equal(t, expectedReader, actualReader)

--- a/slack/response.go
+++ b/slack/response.go
@@ -1,0 +1,81 @@
+// Package slack handles communicating with status pages following the Slack format
+package slack
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/sprak3000/go-client/client"
+	"github.com/sprak3000/go-glitch/glitch"
+	"github.com/sprak3000/xbar-whats-up/status"
+)
+
+// ServiceType is the name we use for various checks
+const ServiceType = "slack"
+
+// Incident represents a single reported status incident
+type Incident struct {
+	ID          string    `json:"id"`
+	DateCreated time.Time `json:"date_created"`
+	DateUpdated time.Time `json:"date_updated"`
+	Title       string    `json:"title"`
+	Type        string    `json:"type"`
+	Status      string    `json:"status"`
+	URL         string    `json:"url"`
+	Services    []string  `json:"services"`
+	Notes       []string  `json:"notes"`
+}
+
+// ClientReader implements the Reader interface for go-client based reading of a service's status
+type ClientReader struct {
+}
+
+// ReadStatus handles communicating with the service to get its status details
+func (cr ClientReader) ReadStatus(serviceFinder client.ServiceFinder, serviceName, slug string) (status.Details, glitch.DataError) {
+	resp := Response{}
+
+	respBytes, err := status.Get(serviceFinder, serviceName, slug)
+	if err != nil {
+		return resp, glitch.NewDataError(err, status.ErrorUnableToMakeClientRequest, fmt.Sprintf("unable to make client request for %s: %v", serviceName, err))
+	}
+
+	uErr := json.Unmarshal(respBytes, &resp)
+	if uErr != nil {
+		return resp, glitch.NewDataError(uErr, status.ErrorUnableToParseClientResponse, fmt.Sprintf("unable to parse client response for %s: %v", serviceName, uErr))
+	}
+
+	return resp, nil
+}
+
+// Response is the structure returned by Slack powered service status pages
+type Response struct {
+	Status          string     `json:"status"`
+	DateCreated     time.Time  `json:"date_created"`
+	DateUpdated     time.Time  `json:"date_updated"`
+	ActiveIncidents []Incident `json:"active_incidents"`
+}
+
+// Indicator returns the current status for the service
+func (r Response) Indicator() string {
+	if r.Status == "active" {
+		return "major"
+	}
+
+	return r.Status
+}
+
+// Name returns the name of the service
+func (r Response) Name() string {
+	return "Slack"
+}
+
+// UpdatedAt returns the date / time of the most recent status update for the service
+func (r Response) UpdatedAt() time.Time {
+	return r.DateUpdated
+}
+
+// URL returns the page the service hosts to display more details about current and past status updates
+func (r Response) URL() string {
+	return "https://status.slack.com/"
+}

--- a/whats-up.1h.go
+++ b/whats-up.1h.go
@@ -1,5 +1,5 @@
 // <xbar.title>What's Up?</xbar.title>
-// <xbar.version>v0.11.0</xbar.version>
+// <xbar.version>v0.12.0</xbar.version>
 // <xbar.author>Luis A. Cruz</xbar.author>
 // <xbar.author.github>sprak3000</xbar.author.github>
 // <xbar.desc>Tracks if services are reporting any outages.</xbar.desc>


### PR DESCRIPTION
- Create `slack` package defining the shape of a Slack status page and how to get details out of it.
- Update reader finder to resolve `slack` type.