### PR TITLE
Issue #31 - Slack status check throwing error

### DIFF
--- a/slack/response.go
+++ b/slack/response.go
@@ -14,9 +14,15 @@ import (
 // ServiceType is the name we use for various checks
 const ServiceType = "slack"
 
+// Note represents additional details about an incident
+type Note struct {
+	DateCreated time.Time `json:"date_created"`
+	Body        string    `json:"body"`
+}
+
 // Incident represents a single reported status incident
 type Incident struct {
-	ID          string    `json:"id"`
+	ID          int       `json:"id"`
 	DateCreated time.Time `json:"date_created"`
 	DateUpdated time.Time `json:"date_updated"`
 	Title       string    `json:"title"`
@@ -24,7 +30,7 @@ type Incident struct {
 	Status      string    `json:"status"`
 	URL         string    `json:"url"`
 	Services    []string  `json:"services"`
-	Notes       []string  `json:"notes"`
+	Notes       []Note    `json:"notes"`
 }
 
 // ClientReader implements the Reader interface for go-client based reading of a service's status

--- a/whats-up.1h.go
+++ b/whats-up.1h.go
@@ -1,5 +1,5 @@
 // <xbar.title>What's Up?</xbar.title>
-// <xbar.version>v0.12.0</xbar.version>
+// <xbar.version>v0.14.1</xbar.version>
 // <xbar.author>Luis A. Cruz</xbar.author>
 // <xbar.author.github>sprak3000</xbar.author.github>
 // <xbar.desc>Tracks if services are reporting any outages.</xbar.desc>


### PR DESCRIPTION
- Create `Note` type and change `slack.Incident.Notes` from `[]string` to `[]Note`.
- Update `slack.Incident.ID` from `string` to `int`.
- Bump version in the xbar doc block.