### PR TITLE
Issue #23: Consider refactor of Display method & Issue #24: Cover Overview.Display with unit tests

### DIFF
--- a/status/overview.go
+++ b/status/overview.go
@@ -3,6 +3,7 @@ package status
 
 import (
 	"fmt"
+	"io"
 )
 
 // List is a mapping of status codes to services reporting that status code
@@ -17,41 +18,33 @@ type Overview struct {
 }
 
 // Display outputs the data in the xbar format
-func (o Overview) Display() {
+func (o Overview) Display(w io.Writer) {
 	switch o.OverallStatus {
 	case "major":
-		fmt.Println("🔴")
+		_, _ = fmt.Fprintln(w, "🔴")
 	case "minor":
-		fmt.Println("🟠")
+		_, _ = fmt.Fprintln(w, "🟠")
 	default:
-		fmt.Println("🟢")
+		_, _ = fmt.Fprintln(w, "🟢")
 	}
 
-	fmt.Println("---")
-	if len(o.List["major"]) > 0 {
-		for _, v := range o.List["major"] {
-			fmt.Println("\u001B[31;1m" + v.Name() + "\u001b[0m" + "\u001b[30m" + " (" + v.UpdatedAt().Format("2006 Jan 02") + ") | href=" + v.URL())
-		}
-	}
+	displayDetails(w, o.List["major"], "\u001B[31;1m")
+	displayDetails(w, o.List["minor"], "\u001b[38;5;208m")
+	displayDetails(w, o.List["none"], "\u001B[32;1m")
 
-	fmt.Println("---")
-	if len(o.List["minor"]) > 0 {
-		for _, v := range o.List["minor"] {
-			fmt.Println("\u001b[38;5;208m" + v.Name() + "\u001b[0m" + "\u001b[30m" + " (" + v.UpdatedAt().Format("2006 Jan 02") + ") | href=" + v.URL())
-		}
-	}
-
-	fmt.Println("---")
-	if len(o.List["none"]) > 0 {
-		for _, v := range o.List["none"] {
-			fmt.Println("\u001B[32;1m" + v.Name() + "\u001b[0m" + "\u001b[30m" + " (" + v.UpdatedAt().Format("2006 Jan 02") + ") | href=" + v.URL())
-		}
-	}
-
-	fmt.Println("---")
+	_, _ = fmt.Fprintln(w, "---")
 	if len(o.Errors) > 0 {
 		for _, v := range o.Errors {
-			fmt.Println(v)
+			_, _ = fmt.Fprintln(w, v)
+		}
+	}
+}
+
+func displayDetails(w io.Writer, details []Details, detailColor string) {
+	_, _ = fmt.Fprintln(w, "---")
+	if len(details) > 0 {
+		for _, v := range details {
+			_, _ = fmt.Fprintln(w, detailColor+v.Name()+"\u001b[0m"+"\u001b[30m"+" ("+v.UpdatedAt().Format("2006 Jan 02")+") | href="+v.URL())
 		}
 	}
 }

--- a/status/overview_test.go
+++ b/status/overview_test.go
@@ -1,0 +1,140 @@
+package status
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnit_Overview_Display(t *testing.T) {
+	var (
+		now          = time.Now()
+		nowFormatted = now.Format("2006 Jan 02")
+	)
+
+	tests := map[string]struct {
+		validate func(t *testing.T)
+	}{
+		"base path- overall status major": {
+			validate: func(t *testing.T) {
+				o := Overview{
+					OverallStatus: "major",
+					List: map[string][]Details{
+						"major": {
+							testResponse{
+								updatedAt: now,
+							},
+						},
+						"minor": {
+							testResponse{
+								updatedAt: now,
+							},
+						},
+						"none": {
+							testResponse{
+								updatedAt: now,
+							},
+						},
+					},
+				}
+
+				var buf bytes.Buffer
+				o.Display(&buf)
+
+				require.Equal(t, "🔴\n---\n\x1b[31;1mTest Service\x1b[0m\x1b[30m ("+nowFormatted+") | href=https://test.service/\n---\n\x1b[38;5;208mTest Service\x1b[0m\x1b[30m ("+nowFormatted+") | href=https://test.service/\n---\n\x1b[32;1mTest Service\x1b[0m\x1b[30m ("+nowFormatted+") | href=https://test.service/\n---\n", buf.String())
+			},
+		},
+		"base path- overall status minor": {
+			validate: func(t *testing.T) {
+				o := Overview{
+					OverallStatus: "minor",
+					List: map[string][]Details{
+						"minor": {
+							testResponse{
+								updatedAt: now,
+							},
+						},
+						"none": {
+							testResponse{
+								updatedAt: now,
+							},
+						},
+					},
+				}
+
+				var buf bytes.Buffer
+				o.Display(&buf)
+
+				require.Equal(t, "🟠\n---\n---\n\x1b[38;5;208mTest Service\x1b[0m\x1b[30m ("+nowFormatted+") | href=https://test.service/\n---\n\x1b[32;1mTest Service\x1b[0m\x1b[30m ("+nowFormatted+") | href=https://test.service/\n---\n", buf.String())
+			},
+		},
+		"base path- overall status none": {
+			validate: func(t *testing.T) {
+				o := Overview{
+					OverallStatus: "none",
+					List: map[string][]Details{
+						"none": {
+							testResponse{
+								updatedAt: now,
+							},
+						},
+					},
+				}
+
+				var buf bytes.Buffer
+				o.Display(&buf)
+
+				require.Equal(t, "🟢\n---\n---\n---\n\x1b[32;1mTest Service\x1b[0m\x1b[30m ("+nowFormatted+") | href=https://test.service/\n---\n", buf.String())
+			},
+		},
+		"base path- has error": {
+			validate: func(t *testing.T) {
+				o := Overview{
+					OverallStatus: "none",
+					List: map[string][]Details{
+						"none": {
+							testResponse{
+								updatedAt: now,
+							},
+						},
+					},
+					Errors: []string{
+						"Something went wrong with a test service.",
+					},
+				}
+
+				var buf bytes.Buffer
+				o.Display(&buf)
+
+				require.Equal(t, "🟢\n---\n---\n---\n\x1b[32;1mTest Service\x1b[0m\x1b[30m ("+nowFormatted+") | href=https://test.service/\n---\nSomething went wrong with a test service.\n", buf.String())
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tc.validate(t)
+		})
+	}
+}
+
+type testResponse struct {
+	updatedAt time.Time
+}
+
+func (tr testResponse) Indicator() string {
+	return ""
+}
+
+func (tr testResponse) Name() string {
+	return "Test Service"
+}
+
+func (tr testResponse) UpdatedAt() time.Time {
+	return tr.updatedAt
+}
+
+func (tr testResponse) URL() string {
+	return "https://test.service/"
+}

--- a/whats-up.1h.go
+++ b/whats-up.1h.go
@@ -1,5 +1,5 @@
 // <xbar.title>What's Up?</xbar.title>
-// <xbar.version>v0.14.1</xbar.version>
+// <xbar.version>v0.15.0</xbar.version>
 // <xbar.author>Luis A. Cruz</xbar.author>
 // <xbar.author.github>sprak3000</xbar.author.github>
 // <xbar.desc>Tracks if services are reporting any outages.</xbar.desc>
@@ -25,5 +25,5 @@ func main() {
 		os.Exit(1)
 	}
 
-	sites.GetOverview(service.NewClientServiceFinder(sites), service.NewReaderServiceFinder()).Display()
+	sites.GetOverview(service.NewClientServiceFinder(sites), service.NewReaderServiceFinder()).Display(os.Stdout)
 }


### PR DESCRIPTION
- Update `Overview.Display` to take in an `io.writer`. Use `Fprintln` with that writer.
- Create helper `displayDetails` to handle iterating over a list of service details and output the appropriate text via the writer passed into it.
- Cover `Overview.Display` with unit tests. Create a test suite type implementing the `Details` interface for use in the tests.
- Have our actual call to `Overview.Display` pass in `os.Stdout` as the writer.