### PR TITLE
Issue #28: "make setup-osx-env" not idempotent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ brew-deps: ## Install tools via Homebrew
 .PHONY: setup-asdf
 setup-asdf: ## Install Go via asdf
 	@echo ">>>> Installing asdf plugins"
-	@asdf plugin add golang
+	-@asdf plugin add golang
 	@echo ">>>> Installing Go via asdf"
 	@asdf install
 

--- a/whats-up.1h.go
+++ b/whats-up.1h.go
@@ -1,5 +1,5 @@
 // <xbar.title>What's Up?</xbar.title>
-// <xbar.version>v0.15.0</xbar.version>
+// <xbar.version>v0.15.1</xbar.version>
 // <xbar.author>Luis A. Cruz</xbar.author>
 // <xbar.author.github>sprak3000</xbar.author.github>
 // <xbar.desc>Tracks if services are reporting any outages.</xbar.desc>


### PR DESCRIPTION
- Ignore errors from `asdf plugin add`. If the plugin is already installed, it throws an error. We don't care if it is already installed. Keep going and finish the other tasks.