### PR TITLE
Issue #38: Table format for services

### DIFF
--- a/.github/workflows/quality-and-tests.yml
+++ b/.github/workflows/quality-and-tests.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.2
+          go-version: 1.20.1
       - name: Install gotestsum
         run: make install-gotestsum
       - name: Install revive

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.19.2
+golang 1.20.1

--- a/service/site.go
+++ b/service/site.go
@@ -74,6 +74,11 @@ func (sites Sites) GetOverview(serviceFinder client.ServiceFinder, readerFinder 
 			continue
 		}
 
+		nameSize := len(resp.Name())
+		if nameSize > overview.LargestStringSize {
+			overview.LargestStringSize = nameSize
+		}
+
 		switch resp.Indicator() {
 		case "major":
 			overview.OverallStatus = "major"

--- a/service/site_test.go
+++ b/service/site_test.go
@@ -84,7 +84,8 @@ func TestUnit_GetOverview(t *testing.T) {
 				return clientReaderSeverityMajor{}, nil
 			},
 			expectedOverview: status.Overview{
-				OverallStatus: "major",
+				OverallStatus:     "major",
+				LargestStringSize: 11,
 				List: map[string][]status.Details{
 					"major": {
 						statuspageio.Response{
@@ -134,7 +135,8 @@ func TestUnit_GetOverview(t *testing.T) {
 				return clientReaderSeverityMinor{}, nil
 			},
 			expectedOverview: status.Overview{
-				OverallStatus: "minor",
+				OverallStatus:     "minor",
+				LargestStringSize: 11,
 				List: map[string][]status.Details{
 					"minor": {
 						statuspageio.Response{
@@ -184,7 +186,8 @@ func TestUnit_GetOverview(t *testing.T) {
 				return clientReaderHasError{}, nil
 			},
 			expectedOverview: status.Overview{
-				OverallStatus: "none",
+				OverallStatus:     "none",
+				LargestStringSize: 11,
 				List: map[string][]status.Details{
 					"none": {
 						statuspageio.Response{

--- a/status/overview.go
+++ b/status/overview.go
@@ -12,7 +12,8 @@ type List map[string][]Details
 // Overview provides an overall status for all services monitored -- most severe status wins -- along with all the
 // services categorized by status
 type Overview struct {
-	OverallStatus string
+	OverallStatus     string
+	LargestStringSize int
 	List
 	Errors []string
 }
@@ -28,9 +29,9 @@ func (o Overview) Display(w io.Writer) {
 		_, _ = fmt.Fprintln(w, "🟢")
 	}
 
-	displayDetails(w, o.List["major"], "\u001B[31;1m")
-	displayDetails(w, o.List["minor"], "\u001b[38;5;208m")
-	displayDetails(w, o.List["none"], "\u001B[32;1m")
+	displayDetails(w, o.LargestStringSize, o.List["major"], "\u001B[31;1m")
+	displayDetails(w, o.LargestStringSize, o.List["minor"], "\u001b[38;5;208m")
+	displayDetails(w, o.LargestStringSize, o.List["none"], "\u001B[32;1m")
 
 	_, _ = fmt.Fprintln(w, "---")
 	if len(o.Errors) > 0 {
@@ -40,11 +41,11 @@ func (o Overview) Display(w io.Writer) {
 	}
 }
 
-func displayDetails(w io.Writer, details []Details, detailColor string) {
+func displayDetails(w io.Writer, largestStringSize int, details []Details, detailColor string) {
 	_, _ = fmt.Fprintln(w, "---")
 	if len(details) > 0 {
 		for _, v := range details {
-			_, _ = fmt.Fprintln(w, detailColor+v.Name()+"\u001b[0m"+"\u001b[30m"+" ("+v.UpdatedAt().Format("2006 Jan 02")+") | href="+v.URL())
+			_, _ = fmt.Fprintf(w, "%s%-*s%s%s %s | font=Monaco href=%s\n", detailColor, largestStringSize+5, v.Name(), "\u001b[0m", "\u001b[30m", v.UpdatedAt().Format("2006 Jan 02"), v.URL())
 		}
 	}
 }

--- a/status/overview_test.go
+++ b/status/overview_test.go
@@ -20,7 +20,8 @@ func TestUnit_Overview_Display(t *testing.T) {
 		"base path- overall status major": {
 			validate: func(t *testing.T) {
 				o := Overview{
-					OverallStatus: "major",
+					OverallStatus:     "major",
+					LargestStringSize: 12,
 					List: map[string][]Details{
 						"major": {
 							testResponse{
@@ -43,13 +44,14 @@ func TestUnit_Overview_Display(t *testing.T) {
 				var buf bytes.Buffer
 				o.Display(&buf)
 
-				require.Equal(t, "🔴\n---\n\x1b[31;1mTest Service\x1b[0m\x1b[30m ("+nowFormatted+") | href=https://test.service/\n---\n\x1b[38;5;208mTest Service\x1b[0m\x1b[30m ("+nowFormatted+") | href=https://test.service/\n---\n\x1b[32;1mTest Service\x1b[0m\x1b[30m ("+nowFormatted+") | href=https://test.service/\n---\n", buf.String())
+				require.Equal(t, "🔴\n---\n\x1b[31;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n\x1b[38;5;208mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n\x1b[32;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n", buf.String())
 			},
 		},
 		"base path- overall status minor": {
 			validate: func(t *testing.T) {
 				o := Overview{
-					OverallStatus: "minor",
+					OverallStatus:     "minor",
+					LargestStringSize: 12,
 					List: map[string][]Details{
 						"minor": {
 							testResponse{
@@ -67,13 +69,14 @@ func TestUnit_Overview_Display(t *testing.T) {
 				var buf bytes.Buffer
 				o.Display(&buf)
 
-				require.Equal(t, "🟠\n---\n---\n\x1b[38;5;208mTest Service\x1b[0m\x1b[30m ("+nowFormatted+") | href=https://test.service/\n---\n\x1b[32;1mTest Service\x1b[0m\x1b[30m ("+nowFormatted+") | href=https://test.service/\n---\n", buf.String())
+				require.Equal(t, "🟠\n---\n---\n\x1b[38;5;208mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n\x1b[32;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n", buf.String())
 			},
 		},
 		"base path- overall status none": {
 			validate: func(t *testing.T) {
 				o := Overview{
-					OverallStatus: "none",
+					OverallStatus:     "none",
+					LargestStringSize: 12,
 					List: map[string][]Details{
 						"none": {
 							testResponse{
@@ -86,13 +89,14 @@ func TestUnit_Overview_Display(t *testing.T) {
 				var buf bytes.Buffer
 				o.Display(&buf)
 
-				require.Equal(t, "🟢\n---\n---\n---\n\x1b[32;1mTest Service\x1b[0m\x1b[30m ("+nowFormatted+") | href=https://test.service/\n---\n", buf.String())
+				require.Equal(t, "🟢\n---\n---\n---\n\x1b[32;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n", buf.String())
 			},
 		},
 		"base path- has error": {
 			validate: func(t *testing.T) {
 				o := Overview{
-					OverallStatus: "none",
+					OverallStatus:     "none",
+					LargestStringSize: 12,
 					List: map[string][]Details{
 						"none": {
 							testResponse{
@@ -108,7 +112,7 @@ func TestUnit_Overview_Display(t *testing.T) {
 				var buf bytes.Buffer
 				o.Display(&buf)
 
-				require.Equal(t, "🟢\n---\n---\n---\n\x1b[32;1mTest Service\x1b[0m\x1b[30m ("+nowFormatted+") | href=https://test.service/\n---\nSomething went wrong with a test service.\n", buf.String())
+				require.Equal(t, "🟢\n---\n---\n---\n\x1b[32;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\nSomething went wrong with a test service.\n", buf.String())
 			},
 		},
 	}


### PR DESCRIPTION
- Update to latest Go 1.X release.
- When iterating and getting status page data, keep track of the longest service name.
- When displaying the services, pad out service names to the length of the longest name and add five spaces before the date.
- Use the default Monaco macOS monospace font for consistent text size.