### PR TITLE
Issue #44 - ioutil.ReadFile and ioutil.WriteFile are deprecated

### DIFF
--- a/configuration/reader.go
+++ b/configuration/reader.go
@@ -1,7 +1,9 @@
 // Package configuration handles reading and writing the configuration file for the plugin
 package configuration
 
-import "io/ioutil"
+import (
+	"os"
+)
 
 // Reader provides the requirements for anyone implementing reading configuration files from disk
 type Reader interface {
@@ -14,5 +16,5 @@ type FileReader struct {
 
 // ReadFile allows us to read configuration off of disk
 func (fr FileReader) ReadFile(filename string) ([]byte, error) {
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }

--- a/configuration/writer.go
+++ b/configuration/writer.go
@@ -1,8 +1,9 @@
+// Package configuration handles reading and writing the configuration file for the plugin
 package configuration
 
 import (
 	"io/fs"
-	"io/ioutil"
+	"os"
 )
 
 // Writer provides the requirements for anyone implementing writing configuration files to disk
@@ -16,5 +17,5 @@ type FileWriter struct {
 
 // WriteFile allows us to write configuration to disk
 func (w FileWriter) WriteFile(filename string, data []byte, perm fs.FileMode) error {
-	return ioutil.WriteFile(filename, data, perm)
+	return os.WriteFile(filename, data, perm)
 }


### PR DESCRIPTION
- Convert to `os` package versions of the calls.