### PR TITLE
Issue #43 - Use go routines / channels to make calls concurrently

### DIFF
--- a/service/site_test.go
+++ b/service/site_test.go
@@ -269,7 +269,7 @@ func TestUnit_GetOverview(t *testing.T) {
 				OverallStatus: "none",
 				List:          map[string][]whatsupstatus.Details{},
 				Errors: []string{
-					"CodeClimate uses an unsupported service type not-a-finger",
+					"Code: [" + ErrorUnsupportedServiceType + "] Message: [CodeClimate uses an unsupported service type not-a-finger] Inner error: [%!s(<nil>)]",
 				},
 			},
 			validate: func(t *testing.T, expectedOverview, actualOverview status.Overview) {


### PR DESCRIPTION
- Use the fan in pattern (c.f., https://youtu.be/f6kdp27TYZs?si=kYE76YvXFH947b3s&t=1874) to fetch status pages concurrently via go routines and a channel.