### PR TITLE
Issue #50 - Better error display

### DIFF
--- a/service/site.go
+++ b/service/site.go
@@ -98,7 +98,7 @@ func (sites Sites) GetOverview(client whatsup.StatusPageClient) status.Overview 
 	overview := status.Overview{
 		OverallStatus: "none",
 		List:          map[string][]whatsupstatus.Details{},
-		Errors:        []string{},
+		Errors:        []status.OverviewError{},
 	}
 
 	c := make(chan readerResult)
@@ -113,7 +113,10 @@ func (sites Sites) GetOverview(client whatsup.StatusPageClient) status.Overview 
 		resp := <-c
 
 		if resp.err != nil {
-			overview.Errors = append(overview.Errors, resp.err.Error())
+			overview.Errors = append(overview.Errors, status.OverviewError{
+				Details: resp.details,
+				Error:   resp.err,
+			})
 			continue
 		}
 

--- a/service/site_test.go
+++ b/service/site_test.go
@@ -171,7 +171,7 @@ func TestUnit_GetOverview(t *testing.T) {
 						slackNoOutageResp,
 					},
 				},
-				Errors: []string{},
+				Errors: []status.OverviewError{},
 			},
 			validate: func(t *testing.T, expectedOverview, actualOverview status.Overview) {
 				require.Equal(t, expectedOverview, actualOverview)
@@ -205,7 +205,7 @@ func TestUnit_GetOverview(t *testing.T) {
 						codeClimateNoOutageResp,
 					},
 				},
-				Errors: []string{},
+				Errors: []status.OverviewError{},
 			},
 			validate: func(t *testing.T, expectedOverview, actualOverview status.Overview) {
 				require.Equal(t, expectedOverview, actualOverview)
@@ -246,8 +246,11 @@ func TestUnit_GetOverview(t *testing.T) {
 						},
 					},
 				},
-				Errors: []string{
-					"Code: [UNABLE_TO_MAKE_CLIENT_REQUEST] Message: [test err] Inner error: [%!s(<nil>)]",
+				Errors: []status.OverviewError{
+					{
+						Details: nil,
+						Error:   glitch.NewDataError(nil, "UNABLE_TO_MAKE_CLIENT_REQUEST", "test err"),
+					},
 				},
 			},
 			validate: func(t *testing.T, expectedOverview, actualOverview status.Overview) {
@@ -268,8 +271,11 @@ func TestUnit_GetOverview(t *testing.T) {
 			expectedOverview: status.Overview{
 				OverallStatus: "none",
 				List:          map[string][]whatsupstatus.Details{},
-				Errors: []string{
-					"Code: [" + ErrorUnsupportedServiceType + "] Message: [CodeClimate uses an unsupported service type not-a-finger] Inner error: [%!s(<nil>)]",
+				Errors: []status.OverviewError{
+					{
+						Details: nil,
+						Error:   glitch.NewDataError(nil, ErrorUnsupportedServiceType, "CodeClimate uses an unsupported service type not-a-finger"),
+					},
 				},
 			},
 			validate: func(t *testing.T, expectedOverview, actualOverview status.Overview) {

--- a/status/overview.go
+++ b/status/overview.go
@@ -5,11 +5,18 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/sprak3000/go-glitch/glitch"
 	whatsupstatus "github.com/sprak3000/go-whatsup-client/status"
 )
 
 // List is a mapping of status codes to services reporting that status code
 type List map[string][]whatsupstatus.Details
+
+// OverviewError bundles the details of a failed overview request
+type OverviewError struct {
+	Details whatsupstatus.Details
+	Error   glitch.DataError
+}
 
 // Overview provides an overall status for all services monitored -- most severe status wins -- along with all the
 // services categorized by status
@@ -17,7 +24,7 @@ type Overview struct {
 	OverallStatus     string
 	LargestStringSize int
 	List
-	Errors []string
+	Errors []OverviewError
 }
 
 // Display outputs the data in the xbar format
@@ -35,17 +42,19 @@ func (o Overview) Display(w io.Writer) {
 	displayDetails(w, o.LargestStringSize, o.List["minor"], "\u001b[38;5;208m")
 	displayDetails(w, o.LargestStringSize, o.List["none"], "\u001B[32;1m")
 
-	_, _ = fmt.Fprintln(w, "---")
 	if len(o.Errors) > 0 {
+		_, _ = fmt.Fprintln(w, "---")
 		for _, v := range o.Errors {
-			_, _ = fmt.Fprintln(w, v)
+			_, _ = fmt.Fprintf(w, "%s%-*s%s%s %s | font=Monaco href=%s\n", "\u001B[31;1m", o.LargestStringSize+5, v.Details.Name(), "\u001b[0m", "\u001b[30m", v.Details.UpdatedAt().Format("2006 Jan 02"), v.Details.URL())
+			_, _ = fmt.Fprintln(w, "----")
+			_, _ = fmt.Fprintf(w, "%s", v.Error.Error())
 		}
 	}
 }
 
 func displayDetails(w io.Writer, largestStringSize int, details []whatsupstatus.Details, detailColor string) {
-	_, _ = fmt.Fprintln(w, "---")
 	if len(details) > 0 {
+		_, _ = fmt.Fprintln(w, "---")
 		for _, v := range details {
 			_, _ = fmt.Fprintf(w, "%s%-*s%s%s %s | font=Monaco href=%s\n", detailColor, largestStringSize+5, v.Name(), "\u001b[0m", "\u001b[30m", v.UpdatedAt().Format("2006 Jan 02"), v.URL())
 		}

--- a/status/overview_test.go
+++ b/status/overview_test.go
@@ -117,7 +117,7 @@ func TestUnit_Overview_Display(t *testing.T) {
 				var buf bytes.Buffer
 				o.Display(&buf)
 
-				require.Equal(t, "🟢\n---\n\x1b[32;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n\x1b[31;1mTest Service     \x1b[0m\x1b[30m 2025 Apr 26 | font=Monaco href=https://test.service/\n----\nCode: [WRONG] Message: [Something went wrong with a test service.] Inner error: [%!s(<nil>)]", buf.String())
+				require.Equal(t, "🟢\n---\n\x1b[32;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n\x1b[31;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n----\nCode: [WRONG] Message: [Something went wrong with a test service.] Inner error: [%!s(<nil>)]", buf.String())
 			},
 		},
 	}

--- a/status/overview_test.go
+++ b/status/overview_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sprak3000/go-glitch/glitch"
 	whatsupstatus "github.com/sprak3000/go-whatsup-client/status"
 	"github.com/stretchr/testify/require"
 )
@@ -45,7 +46,7 @@ func TestUnit_Overview_Display(t *testing.T) {
 				var buf bytes.Buffer
 				o.Display(&buf)
 
-				require.Equal(t, "🔴\n---\n\x1b[31;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n\x1b[38;5;208mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n\x1b[32;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n", buf.String())
+				require.Equal(t, "🔴\n---\n\x1b[31;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n\x1b[38;5;208mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n\x1b[32;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n", buf.String())
 			},
 		},
 		"base path- overall status minor": {
@@ -70,7 +71,7 @@ func TestUnit_Overview_Display(t *testing.T) {
 				var buf bytes.Buffer
 				o.Display(&buf)
 
-				require.Equal(t, "🟠\n---\n---\n\x1b[38;5;208mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n\x1b[32;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n", buf.String())
+				require.Equal(t, "🟠\n---\n\x1b[38;5;208mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n\x1b[32;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n", buf.String())
 			},
 		},
 		"base path- overall status none": {
@@ -90,7 +91,7 @@ func TestUnit_Overview_Display(t *testing.T) {
 				var buf bytes.Buffer
 				o.Display(&buf)
 
-				require.Equal(t, "🟢\n---\n---\n---\n\x1b[32;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n", buf.String())
+				require.Equal(t, "🟢\n---\n\x1b[32;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n", buf.String())
 			},
 		},
 		"base path- has error": {
@@ -105,15 +106,18 @@ func TestUnit_Overview_Display(t *testing.T) {
 							},
 						},
 					},
-					Errors: []string{
-						"Something went wrong with a test service.",
+					Errors: []OverviewError{
+						{
+							Details: testResponse{updatedAt: now},
+							Error:   glitch.NewDataError(nil, "WRONG", "Something went wrong with a test service."),
+						},
 					},
 				}
 
 				var buf bytes.Buffer
 				o.Display(&buf)
 
-				require.Equal(t, "🟢\n---\n---\n---\n\x1b[32;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\nSomething went wrong with a test service.\n", buf.String())
+				require.Equal(t, "🟢\n---\n\x1b[32;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n\x1b[31;1mTest Service     \x1b[0m\x1b[30m 2025 Apr 26 | font=Monaco href=https://test.service/\n----\nCode: [WRONG] Message: [Something went wrong with a test service.] Inner error: [%!s(<nil>)]", buf.String())
 			},
 		},
 	}


### PR DESCRIPTION
- Add new structure to hold details and error of failed site pull.
- Update display of errors to show site name in red along with sub-menu containing error string.