### PR TITLE
Issue #50 - Better error display

### DIFF
--- a/service/site.go
+++ b/service/site.go
@@ -63,8 +63,10 @@ func (s *Site) UnmarshalJSON(data []byte) error {
 type Sites map[string]Site
 
 type readerResult struct {
-	details whatsupstatus.Details
-	err     glitch.DataError
+	serviceName string
+	serviceURL  string
+	details     whatsupstatus.Details
+	err         glitch.DataError
 }
 
 func readStatusPage(c whatsup.StatusPageClient, serviceName string, s Site) readerResult {
@@ -81,15 +83,19 @@ func readStatusPage(c whatsup.StatusPageClient, serviceName string, s Site) read
 	default:
 		// Unsupported at this time
 		return readerResult{
-			details: nil,
-			err:     glitch.NewDataError(nil, ErrorUnsupportedServiceType, serviceName+" uses an unsupported service type "+s.Type),
+			serviceName: serviceName,
+			serviceURL:  s.URL.String(),
+			details:     nil,
+			err:         glitch.NewDataError(nil, ErrorUnsupportedServiceType, serviceName+" uses an unsupported service type "+s.Type),
 		}
 	}
 
 	resp, err := reader.ReadStatus(c)
 	return readerResult{
-		details: resp,
-		err:     err,
+		serviceName: serviceName,
+		serviceURL:  s.URL.String(),
+		details:     resp,
+		err:         err,
 	}
 }
 
@@ -114,8 +120,10 @@ func (sites Sites) GetOverview(client whatsup.StatusPageClient) status.Overview 
 
 		if resp.err != nil {
 			overview.Errors = append(overview.Errors, status.OverviewError{
-				Details: resp.details,
-				Error:   resp.err,
+				ServiceName: resp.serviceName,
+				ServiceURL:  resp.serviceURL,
+				Details:     resp.details,
+				Error:       resp.err,
 			})
 			continue
 		}

--- a/service/site_test.go
+++ b/service/site_test.go
@@ -248,8 +248,10 @@ func TestUnit_GetOverview(t *testing.T) {
 				},
 				Errors: []status.OverviewError{
 					{
-						Details: nil,
-						Error:   glitch.NewDataError(nil, "UNABLE_TO_MAKE_CLIENT_REQUEST", "test err"),
+						ServiceName: "CircleCI",
+						ServiceURL:  "https://status.circleci.com/api/v2/status.json",
+						Details:     nil,
+						Error:       glitch.NewDataError(nil, "UNABLE_TO_MAKE_CLIENT_REQUEST", "test err"),
 					},
 				},
 			},
@@ -273,8 +275,10 @@ func TestUnit_GetOverview(t *testing.T) {
 				List:          map[string][]whatsupstatus.Details{},
 				Errors: []status.OverviewError{
 					{
-						Details: nil,
-						Error:   glitch.NewDataError(nil, ErrorUnsupportedServiceType, "CodeClimate uses an unsupported service type not-a-finger"),
+						ServiceName: "CodeClimate",
+						ServiceURL:  "https://status.codeclimate.com/api/v2/status.json",
+						Details:     nil,
+						Error:       glitch.NewDataError(nil, ErrorUnsupportedServiceType, "CodeClimate uses an unsupported service type not-a-finger"),
 					},
 				},
 			},

--- a/status/overview.go
+++ b/status/overview.go
@@ -4,6 +4,7 @@ package status
 import (
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/sprak3000/go-glitch/glitch"
 	whatsupstatus "github.com/sprak3000/go-whatsup-client/status"
@@ -14,8 +15,10 @@ type List map[string][]whatsupstatus.Details
 
 // OverviewError bundles the details of a failed overview request
 type OverviewError struct {
-	Details whatsupstatus.Details
-	Error   glitch.DataError
+	ServiceName string
+	ServiceURL  string
+	Details     whatsupstatus.Details
+	Error       glitch.DataError
 }
 
 // Overview provides an overall status for all services monitored -- most severe status wins -- along with all the
@@ -44,10 +47,9 @@ func (o Overview) Display(w io.Writer) {
 
 	if len(o.Errors) > 0 {
 		_, _ = fmt.Fprintln(w, "---")
-		for _, v := range o.Errors {
-			_, _ = fmt.Fprintf(w, "%s%-*s%s%s %s | font=Monaco href=%s\n", "\u001B[31;1m", o.LargestStringSize+5, v.Details.Name(), "\u001b[0m", "\u001b[30m", v.Details.UpdatedAt().Format("2006 Jan 02"), v.Details.URL())
-			_, _ = fmt.Fprintln(w, "----")
-			_, _ = fmt.Fprintf(w, "%s", v.Error.Error())
+		for _, e := range o.Errors {
+			_, _ = fmt.Fprintf(w, "⁉️ %s%-*s%s%s %s | font=Monaco href=%s\n", "\u001B[31;1m", o.LargestStringSize+2, e.ServiceName, "\u001b[0m", "\u001b[30m", time.Now().Format("2006 Jan 02"), e.ServiceURL)
+			_, _ = fmt.Fprintln(w, "-- Error fetching site status.")
 		}
 	}
 }

--- a/status/overview_test.go
+++ b/status/overview_test.go
@@ -108,8 +108,10 @@ func TestUnit_Overview_Display(t *testing.T) {
 					},
 					Errors: []OverviewError{
 						{
-							Details: testResponse{updatedAt: now},
-							Error:   glitch.NewDataError(nil, "WRONG", "Something went wrong with a test service."),
+							ServiceName: "Test Service",
+							ServiceURL:  "https://test.service/",
+							Details:     testResponse{updatedAt: now},
+							Error:       glitch.NewDataError(nil, "WRONG", "Something went wrong with a test service."),
 						},
 					},
 				}
@@ -117,7 +119,7 @@ func TestUnit_Overview_Display(t *testing.T) {
 				var buf bytes.Buffer
 				o.Display(&buf)
 
-				require.Equal(t, "🟢\n---\n\x1b[32;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n\x1b[31;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n----\nCode: [WRONG] Message: [Something went wrong with a test service.] Inner error: [%!s(<nil>)]", buf.String())
+				require.Equal(t, "🟢\n---\n\x1b[32;1mTest Service     \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n---\n⁉️ \x1b[31;1mTest Service  \x1b[0m\x1b[30m "+nowFormatted+" | font=Monaco href=https://test.service/\n-- Error fetching site status.\n", buf.String())
 			},
 		},
 	}


### PR DESCRIPTION
- Add service name and service URL to the overview error structure.
- Have the reader response when making calls to the status pages return the service name and service URL.
- Update the error display according to the above changes.